### PR TITLE
Fix issue #46, changes to make LinkAccount card show

### DIFF
--- a/django_alexa/internal/response_builder.py
+++ b/django_alexa/internal/response_builder.py
@@ -110,7 +110,7 @@ class ResponseBuilder(object):
             data["outputSpeech"] = cls._create_speech(
                 message=message, is_ssml=message_is_ssml
             )
-        if title or content:
+        if title or content or card_type == "LinkAccount":
             data["card"] = cls._create_card(
                 title=title,
                 content=content,


### PR DESCRIPTION
Fixes #46.
Have testing this against a skill and it works as expected, adding title or content is no longer required.